### PR TITLE
Update UndetectedChromeDriver.cs debug port fixed

### DIFF
--- a/UndetectedChromeDriver/UndetectedChromeDriver.cs
+++ b/UndetectedChromeDriver/UndetectedChromeDriver.cs
@@ -86,7 +86,7 @@ namespace SeleniumUndetectedChromeDriver
             if (options.DebuggerAddress != null)
                 throw new Exception("Options is already used, please create new ChromeOptions.");
             var debugHost = "127.0.0.1";
-            var debugPort = findFreePort();
+            var debugPort = port !=0 ? port : findFreePort();
             options.AddArgument($"--remote-debugging-host={debugHost}");
             options.AddArgument($"--remote-debugging-port={debugPort}");
             options.DebuggerAddress = $"{debugHost}:{debugPort}";


### PR DESCRIPTION
To use a custom port with the Create() Constructor the debug port and the chromdriver port has to be the same, with this change if there is a pre set port the port listener and the chromedriver port would be the same and the can connect